### PR TITLE
Add stupxd@Cartomancer mod

### DIFF
--- a/mods/stupxd@Cartomancer/description.md
+++ b/mods/stupxd@Cartomancer/description.md
@@ -1,0 +1,19 @@
+# Cartomancer
+Balatro mod with quality of life deck & UI optimizations
+
+## Features
+- Limit amount of cards visible in your deck pile, to make it appear smaller. Default limit is 100 cards, which can be modified in mod config menu.
+
+- Improved deck view
+
+- Custom scoring flames intensity and SFX volume.
+
+- Hide non-essential (edition) shaders.
+
+- Improved jokers management
+
+
+## Settings
+Settings for this mod can be found under Mods tab, if you use Steamodded 1.0.0 - find Cartomancer, and open Config tab.
+
+If you only use Lovely, go to Settings and open the Cartomancer tab.

--- a/mods/stupxd@Cartomancer/meta.json
+++ b/mods/stupxd@Cartomancer/meta.json
@@ -1,0 +1,9 @@
+{
+    "title": "Cartomancer",
+    "requires-steamodded": false,
+    "requires-talisman": false,
+    "categories": ["Quality of Life"],
+    "author": "stupxd",
+    "repo": "https://github.com/stupxd/Cartomancer",
+    "downloadURL": "https://github.com/stupxd/Cartomancer/releases/download/v.4.10/Cartomancer-v.4.10-fix-fix.zip"
+}  


### PR DESCRIPTION
Cartomancer is a mod that gives QoL optimizations to the deck and UI, such as limiting the amount of cards rendered on the deck pile.