### PR TITLE
Add DivvyCr@Balatro-Preview mod

### DIFF
--- a/mods/DivvyCr@Balatro-Preview/description.md
+++ b/mods/DivvyCr@Balatro-Preview/description.md
@@ -1,0 +1,12 @@
+# Divvy's Preview for Balatro
+Simulate the score and the dollars that you will get by playing the selected cards!
+
+## Features
+- Score and dollar preview **without side-effects**!
+- **Updates in real-time** when changing selected cards, changing joker order, or using consumables!
+- Can preview score even when cards are face-down!
+- Perfectly **predicts random effects**...
+- ... or not! There is an option to show the **minimum and maximum possible scores** when probabilities are involved!
+
+## Warning
+This mod **only simulates vanilla jokers**, it will not simulate modded jokers unless the mod that adds them supports this mod.

--- a/mods/DivvyCr@Balatro-Preview/meta.json
+++ b/mods/DivvyCr@Balatro-Preview/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "Balatro-Preview",
+  "requires-steamodded": false,
+  "requires-talisman": false,
+  "categories": ["Quality of Life", "Miscellaneous"],
+  "author": "DivvyCr",
+  "repo": "https://github.com/DivvyCr/Balatro-Preview",
+  "downloadURL": "https://github.com/DivvyCr/Balatro-Preview/releases/latest/download/DOWNLOAD.zip"
+}


### PR DESCRIPTION
This mod adds a score and money preview of the selected hand.

However, this mod only simulates vanilla jokers for the preview, for modded jokers, it's up to the mod developer to support this mod.