### PR TITLE
Set folderName property for ItsFlowwey@FlowerPot

### DIFF
--- a/mods/ItsFlowwey@FlowerPot/meta.json
+++ b/mods/ItsFlowwey@FlowerPot/meta.json
@@ -5,5 +5,6 @@
     "categories": ["Technical"],
     "author": "ItsFlowwey",
     "repo":"https://github.com/GauntletGames-2086/Flower-Pot",
-    "downloadURL": "https://github.com/GauntletGames-2086/Flower-Pot/archive/refs/heads/master.zip"
+    "downloadURL": "https://github.com/GauntletGames-2086/Flower-Pot/archive/refs/heads/master.zip",
+    "folderName": "Flower-Pot"
 }


### PR DESCRIPTION
FlowerPot needs to have its install folder specifically named "Flower-Pot", otherwise it will make the game crash.
Discovered this problem after trying to launch Balatro with FlowerPot installed.