### PR TITLE
Update Fusion Jokers URL to elbe's fork

### DIFF
--- a/mods/Itayfeder@FusionJokers/meta.json
+++ b/mods/Itayfeder@FusionJokers/meta.json
@@ -4,6 +4,6 @@
     "requires-talisman": false,
     "categories": ["Joker"],
     "author": "itayfeder",
-    "repo":"https://github.com/itayfeder/Fusion-Jokers",
-    "downloadURL":"https://github.com/itayfeder/Fusion-Jokers/archive/refs/heads/main.zip"
+    "repo":"https://github.com/lshtech/Fusion-Jokers",
+    "downloadURL":"https://github.com/lshtech/Fusion-Jokers/archive/refs/heads/main.zip"
 }


### PR DESCRIPTION
Original Fusion Jokers is abandoned and has many critical bugs; this fork fixes those