### PR TITLE
Disable `update-mod-versions` job on forks

### DIFF
--- a/.github/workflows/update-mod-versions.yml
+++ b/.github/workflows/update-mod-versions.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-versions:
     runs-on: ubuntu-latest
-    
+    if: github.repository == 'skyline69/balatro-mod-index'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds a single-line fix to only run the `update-versions` job when the repo matches 'skyline69/balatro-mod-index'. This will prevent the workflow from running automatically in all forks.