### PR TITLE
Fork issue fix

### DIFF
--- a/.github/workflows/update-mod-versions.yml
+++ b/.github/workflows/update-mod-versions.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-versions:
     runs-on: ubuntu-latest
-    
+    if: github.repository == 'skyline69/balatro-mod-index'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/mods/Betmma@BetmmaMods/meta.json
+++ b/mods/Betmma@BetmmaMods/meta.json
@@ -9,5 +9,5 @@
   "repo": "https://github.com/betmma/my_balatro_mods",
   "downloadURL": "https://github.com/betmma/my_balatro_mods/archive/refs/heads/main.zip",
   "automatic-version-check": true,
-  "version": "472b774"
+  "version": "f082372"
 }


### PR DESCRIPTION
This pull request includes changes to a GitHub Actions workflow and a metadata file for a mod. The most important changes are:

Workflow condition update:
* [`.github/workflows/update-mod-versions.yml`](diffhunk://#diff-08c6175ddce4a9d49c79d12925be3c4f705913aadcd437a10b8bde3bde8fe740L11-R11): Added a condition to the `update-versions` job to run only if the repository is `skyline69/balatro-mod-index`.

Metadata update:
* [`mods/Betmma@BetmmaMods/meta.json`](diffhunk://#diff-91e263ad0127035020f677f4feeeb3759ac5ce30b3a31f27bb0f737629732797L12-R12): Updated the `version` field from `472b774` to `f082372`.