### PR TITLE
Set and clarify `requires-talisman` as a required parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This file stores essential metadata in JSON format. **Make sure you adhere to th
   "categories": ["Content"],
   "author": "Joe Mama",
   "repo": "https://github.com/joemama/extended-cards",
-  "downloadURL": "https://github.com/joemama/extended-cards/releases/latest/extended-cards.tar.gz",
+  "downloadURL": "https://github.com/joemama/extended-cards/releases/latest/extended-cards.zip",
   "folderName": "ExtendedCards",
   "version": "1.0.0",
   "automatic-version-check": true
@@ -44,7 +44,7 @@ This file stores essential metadata in JSON format. **Make sure you adhere to th
 ```
 - **title**: The name of your mod.
 - **requires-steamodded**: If your mod requires the [Steamodded](https://github.com/Steamodded/smods) mod loader, set this to `true`.
-- *requires-talisman*: (*Optional*) If your mod requires the [Talisman](https://github.com/MathIsFun0/Talisman) mod, set this to `true`.
+- **requires-talisman**: If your mod requires the [Talisman](https://github.com/MathIsFun0/Talisman) mod, set this to `true`.
 - **categories**: Must contain at least one of `Content`, `Joker`, `Quality of Life`, `Technical`, `Miscellaneous`, `Resource Packs` or `API`.
 - **author**: Your chosen username or handle.
 - **repo**: A link to your mod's repository.

--- a/mods/r0maps@GigaJokers/meta.json
+++ b/mods/r0maps@GigaJokers/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "GigaJokers",
   "requires-steamodded": true,
+  "requires-talisman": false,
   "categories": ["Resource Packs"],
   "author": "r0maps, Azurysu",
   "repo": "https://github.com/r0maps/GigaJokers/tree/main",

--- a/mods/r0maps@GigaJokers/meta.json
+++ b/mods/r0maps@GigaJokers/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "GigaJokers",
   "requires-steamodded": true,
+  "requires-talisman": false,
   "categories": [
     "Resource Packs"
   ],

--- a/schema/meta.schema.json
+++ b/schema/meta.schema.json
@@ -43,6 +43,6 @@
       "type": "boolean"
     }
   },
-  "required": ["title", "requires-steamodded", "categories", "author", "repo", "downloadURL"]
+  "required": ["title", "requires-steamodded", "requires-talisman", "categories", "author", "repo", "downloadURL"]
 }
 


### PR DESCRIPTION
- Set `requires-talisman` as a required parameter in schema
- Marked `requires-talisman` as a required parameter in README

Balatro Mod Manager appears to reject mods without this parameter. While it would ideally not need be required and default to false, for the sake of compatibility with all versions of BMM this is the easiest solution.