### PR TITLE
Fix spire-winder@Balatro-Draft `downloadURL`

### DIFF
--- a/mods/spire-winder@Balatro-Draft/meta.json
+++ b/mods/spire-winder@Balatro-Draft/meta.json
@@ -7,7 +7,7 @@
   ],
   "author": "spire-winder",
   "repo": "https://github.com/spire-winder/Balatro-Draft",
-  "downloadURL": "https://github.com/Eremel/Galdur/archive/refs/heads/master.zip",
-  "automatic-version-check": true,
-  "version": "d4fbaeb"
+  "downloadURL": "https://github.com/spire-winder/Balatro-Draft/releases/download/v0.5.2/Balatro-Draft-v0.5.2.zip",
+  "automatic-version-check": false,
+  "version": "v0.5.2"
 }


### PR DESCRIPTION
Was incorrectly using a link to the files for Eremel@Galdur.
Manually set version to allow bad previous versions to update, which would otherwise be unaware of the change and remain on `d4fbaeb`