### PR TITLE
Add Opal@ChallengerDeep mod

### DIFF
--- a/mods/Opal@ChallengerDeep/description.md
+++ b/mods/Opal@ChallengerDeep/description.md
@@ -1,0 +1,11 @@
+# Challenger Deep
+
+A back-end Balatro mod that adds 100+ Custom Rules to be used in Challenges - for banning Editions, enabling Stickers, and fine-tuning each Challenge to your liking.
+
+## Rules
+
+Challenger Deep adds over 100 new Custom Rules. To use them in your Challenge, place them in the Custom part of your rules (challenge={rules={custom={}}}), and check the README file on the GitHub repository for formatting.
+
+## Cross-mod Functionality
+
+Challenger Deep contains Rules that can remove Bunco and Cryptid editions, and add Bunco Stickers to your challenge.

--- a/mods/Opal@ChallengerDeep/meta.json
+++ b/mods/Opal@ChallengerDeep/meta.json
@@ -1,0 +1,10 @@
+{
+	"title": "Challenger Deep",
+	"requires-steamodded": true,
+	"requires-talisman": false,
+	"categories": ["API", "Technical"],
+	"author": "Opal",
+	"repo": "https://github.com/OOkayOak/Challenger-Deep",
+	"downloadURL": "https://github.com/OOkayOak/Challenger-Deep/releases/latest",
+	"automatic-version-check": true
+}


### PR DESCRIPTION
Challenger Deep is a mod that adds 100+ Custom Rules for Challenges, including but not limited to:
- Banning specific Editions from appearing
- Permitting Stickers to appear, independent of each other
- Shop modifications, such as forcing Jokers or removing Vouchers/Rerolls