### PR TITLE
Improvements to Mod validator `check_mod.yml`

### DIFF
--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -18,12 +18,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: imagemagick
-          execute_install_scripts: true
-
-      - name: DEBUG Check cache restore state
-        run: | 
-          ls -gh /usr/bin
-          ls -gh /usr/local/bin
+          version: 8:6.9.12.98+dfsg1-5.2build2
 
       - name: Identify Changed Mods
         id: find-changed-mods
@@ -102,7 +97,7 @@ jobs:
               
               if [ -f "$THUMBNAIL" ]; then
                 # Extract width and height using ImageMagick
-                DIMENSIONS=$(/usr/bin/identify -format "%wx%h" "$THUMBNAIL")
+                DIMENSIONS=$(/usr/bin/identify-im6.q16 -format "%wx%h" "$THUMBNAIL")
                 WIDTH=$(echo "$DIMENSIONS" | cut -dx -f1)
                 HEIGHT=$(echo "$DIMENSIONS" | cut -dx -f2)
                 

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -28,10 +28,6 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
 
-          # Debug the API response
-          echo "Debug - API Response Type: $(echo "$API_RESPONSE" | jq -r 'type')"
-          echo "Debug - First 300 chars of response: $(echo "$API_RESPONSE" | head -c 300)"
-          
           # Use fallback method if API fails
           if echo "$API_RESPONSE" | jq -e 'if type=="array" then true else false end' > /dev/null; then
             echo "Using GitHub API method to find changed files"

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -14,7 +14,15 @@ jobs:
         with:
           fetch-depth: 0  # Get full history for comparing changes
 
-      - name: Install ImageMagick
+      - name: Cache ImageMagick
+        uses: actions/cache@v3
+        with:
+          path: /usr/bin/identify
+          key: imagemagick-cache-${{ runner.os }}-${{ hashFiles('**/check-mod.yml') }}
+          restore-keys: imagemagick-cache-${{ runner.os }}-
+
+      - name: Install ImageMagick (if not cached)
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y imagemagick

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Identify Changed Mods
         id: find-changed-mods
         run: |
-          # Get the list of files changed in the PR using GitHub API with PAT
+          # Get the list of files changed in the PR using GitHub API
           API_RESPONSE=$(curl -s -X GET \
-            -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
           

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -88,6 +88,7 @@ jobs:
           done < changed_mods.txt
 
       - name: Check Thumbnail Dimensions
+        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           while read -r mod_path; do
@@ -96,7 +97,8 @@ jobs:
               THUMBNAIL="$mod_path/thumbnail.jpg"
               
               if [ -f "$THUMBNAIL" ]; then
-                # Extract width and height using ImageMagick
+                # Extract width and height using ImageMagick identify
+                # Using identify-im6.q16 directly as identify is a symlink that is not created by the cache restoration
                 DIMENSIONS=$(/usr/bin/identify-im6.q16 -format "%wx%h" "$THUMBNAIL")
                 WIDTH=$(echo "$DIMENSIONS" | cut -dx -f1)
                 HEIGHT=$(echo "$DIMENSIONS" | cut -dx -f2)

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -88,7 +88,7 @@ jobs:
           done < changed_mods.txt
 
       - name: Check Thumbnail Dimensions
-        if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
+        if: always() && steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           while read -r mod_path; do
             if [ -d "$mod_path" ]; then
@@ -112,7 +112,7 @@ jobs:
           done < changed_mods.txt
 
       - name: Validate JSON Format
-        if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
+        if: always() && steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           # Use jq to validate each JSON file
           while read -r mod_path; do
@@ -125,14 +125,14 @@ jobs:
           done < changed_mods.txt
 
       - name: Validate meta.json Against Schema
-        if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
+        if: always() && steps.find-changed-mods.outputs.changed_mods_found == 'true'
         uses: dsanders11/json-schema-validate-action@v1.2.0
         with:
           schema: "./schema/meta.schema.json"
           files: ${{ steps.find-changed-mods.outputs.meta_json_files }}
 
       - name: Validate Download URLs
-        if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
+        if: always() && steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           while read -r mod_path; do
             if [ -d "$mod_path" ]; then

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -18,6 +18,12 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: imagemagick
+          execute_install_scripts: true
+
+      - name: DEBUG Check cache restore state
+        run: | 
+          ls -gh /usr/bin
+          ls -gh /usr/local/bin
 
       - name: Identify Changed Mods
         id: find-changed-mods
@@ -96,7 +102,7 @@ jobs:
               
               if [ -f "$THUMBNAIL" ]; then
                 # Extract width and height using ImageMagick
-                DIMENSIONS=$(identify -format "%wx%h" "$THUMBNAIL")
+                DIMENSIONS=$(/usr/bin/identify -format "%wx%h" "$THUMBNAIL")
                 WIDTH=$(echo "$DIMENSIONS" | cut -dx -f1)
                 HEIGHT=$(echo "$DIMENSIONS" | cut -dx -f2)
                 

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -110,6 +110,7 @@ jobs:
           done < changed_mods.txt
 
       - name: Validate JSON Format
+        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           # Use jq to validate each JSON file
@@ -123,6 +124,7 @@ jobs:
           done < changed_mods.txt
 
       - name: Validate meta.json Against Schema
+        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         uses: dsanders11/json-schema-validate-action@v1.2.0
         with:
@@ -130,6 +132,7 @@ jobs:
           files: ${{ steps.find-changed-mods.outputs.meta_json_files }}
 
       - name: Validate Download URLs
+        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           while read -r mod_path; do

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -14,18 +14,10 @@ jobs:
         with:
           fetch-depth: 0  # Get full history for comparing changes
 
-      - name: Cache ImageMagick
-        uses: actions/cache@v3
+      - name: Use ImageMagick from cache
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          path: /usr/bin/identify
-          key: imagemagick-cache-${{ runner.os }}-${{ hashFiles('**/check-mod.yml') }}
-          restore-keys: imagemagick-cache-${{ runner.os }}-
-
-      - name: Install ImageMagick (if not cached)
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y imagemagick
+          packages: imagemagick
 
       - name: Identify Changed Mods
         id: find-changed-mods
@@ -35,7 +27,7 @@ jobs:
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
-          
+
           # Debug the API response
           echo "Debug - API Response Type: $(echo "$API_RESPONSE" | jq -r 'type')"
           echo "Debug - First 300 chars of response: $(echo "$API_RESPONSE" | head -c 300)"

--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -88,7 +88,6 @@ jobs:
           done < changed_mods.txt
 
       - name: Check Thumbnail Dimensions
-        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           while read -r mod_path; do
@@ -113,7 +112,6 @@ jobs:
           done < changed_mods.txt
 
       - name: Validate JSON Format
-        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           # Use jq to validate each JSON file
@@ -127,7 +125,6 @@ jobs:
           done < changed_mods.txt
 
       - name: Validate meta.json Against Schema
-        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         uses: dsanders11/json-schema-validate-action@v1.2.0
         with:
@@ -135,7 +132,6 @@ jobs:
           files: ${{ steps.find-changed-mods.outputs.meta_json_files }}
 
       - name: Validate Download URLs
-        continue-on-error: true
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'
         run: |
           while read -r mod_path; do


### PR DESCRIPTION
- Fix invalid use of PAT auth token, replace with standard `secrets.GITHUB_TOKEN`
- Create and use cached ImageMagick installation (fixed version 8:6.9.12.98+dfsg1-5.2build2) for significantly improved runtime
    - Previously ~50-90s, now down to ~6-10s
- Run validator steps even when previous validators have failed, to allow reporting multiple errors with a single action:
   - Check Thumbnail Dimensions
   - Validate JSON Format
   - Validate meta.json Against Schema
   - Validate Download URLs