### PR TITLE
Add Opal@ChallengerExamples

### DIFF
--- a/mods/Opal@ChallengerExamples/description.md
+++ b/mods/Opal@ChallengerExamples/description.md
@@ -1,0 +1,10 @@
+# Challenger Examples
+
+A Balatro Challenge mod that adds Challenges focused on showing **Challenger Deep** functionality.
+
+## Content
+
+Challenger Examples provides some (likely unbalanced) Challenges - from focuses on Economy, to adding another Boss Blind.
+
+## NOTE:
+Challenger Examples requires [Challenger Deep](https://github.com/OOkayOak/Challenger-Deep).

--- a/mods/Opal@ChallengerExamples/meta.json
+++ b/mods/Opal@ChallengerExamples/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "Challenger Examples",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": [
+    "Content"
+  ],
+  "author": "Opal",
+  "repo": "https://github.com/OOkayOak/Challenger-Examples",
+  "downloadURL": "https://github.com/OOkayOak/Challenger-Examples/releases/latest/download/ChallengerExamples.zip",
+  "automatic-version-check": true,
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
Challenger Examples is a mod that adds Challenges focused on Challenger Deep's rules. Currently, there are 7 Challenges.