### PR TITLE
Add the API category to 4 mods

### DIFF
--- a/mods/Eremel@Galdur/meta.json
+++ b/mods/Eremel@Galdur/meta.json
@@ -3,7 +3,8 @@
   "requires-steamodded": true,
   "requires-talisman": false,
   "categories": [
-    "Quality of Life"
+    "Quality of Life",
+    "API"
   ],
   "author": "Eremel",
   "repo": "https://github.com/Eremel/Galdur",

--- a/mods/Itayfeder@FusionJokers/meta.json
+++ b/mods/Itayfeder@FusionJokers/meta.json
@@ -3,7 +3,8 @@
   "requires-steamodded": true,
   "requires-talisman": false,
   "categories": [
-    "Joker"
+    "Joker",
+    "API"
   ],
   "author": "itayfeder",
   "repo": "https://github.com/lshtech/Fusion-Jokers",

--- a/mods/Larswijn@CardSleeves/meta.json
+++ b/mods/Larswijn@CardSleeves/meta.json
@@ -3,7 +3,8 @@
   "requires-steamodded": true,
   "requires-talisman": false,
   "categories": [
-    "Content"
+    "Content",
+    "API"
   ],
   "author": "Larswijn",
   "repo": "https://github.com/larswijn/CardSleeves",

--- a/mods/wingedcatgirl@SpectrumFramework/meta.json
+++ b/mods/wingedcatgirl@SpectrumFramework/meta.json
@@ -3,7 +3,8 @@
   "requires-steamodded": true,
   "requires-talisman": false,
   "categories": [
-    "Miscellaneous"
+    "Miscellaneous",
+    "API"
   ],
   "author": "wingedcatgirl",
   "repo": "https://github.com/wingedcatgirl/SpectrumFramework",


### PR DESCRIPTION
Includes Cardsleeves, FusionJokers, Galdur and SpectrumFramework. Based on https://balatromods.miraheze.org/wiki/Category:API_Mods.

Closes #169 