### PR TITLE
Fix `meta.json` validator failing when multiple mods changed

### DIFF
--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -53,19 +53,14 @@ jobs:
           cat changed_mods.txt
           echo "changed_mods_found=true" >> $GITHUB_OUTPUT
           
-          # Create a comma-separated list for JSON schema validation
-          META_JSON_FILES=""
-          while read -r mod_path; do
-            if [ -f "$mod_path/meta.json" ]; then
-              if [ -z "$META_JSON_FILES" ]; then
-                META_JSON_FILES="$mod_path/meta.json"
-              else
-                META_JSON_FILES="$META_JSON_FILES,$mod_path/meta.json"
-              fi
-            fi
-          done < changed_mods.txt
-          
-          echo "meta_json_files=$META_JSON_FILES" >> $GITHUB_OUTPUT
+          # Create a newline-separated list for JSON schema validation
+          META_JSON_FILES=$(while read -r mod_path; do
+            [ -f "$mod_path/meta.json" ] && echo "$mod_path/meta.json"
+          done < changed_mods.txt)
+                  
+          echo "meta_json_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$META_JSON_FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Check Required Files
         if: steps.find-changed-mods.outputs.changed_mods_found == 'true'


### PR DESCRIPTION
- Simplify creation of META_JSON_FILES list
- Provide multi-line `META_JSON_FILES` to `$GITHUB_OUTPUT` using [recommended syntax](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings)