### PR TITLE
revert <https://github.com/skyline69/balatro-mod-index/commit/6731690> where unnecessary

### DIFF
--- a/mods/StarletDevil@AzzysJokers/meta.json
+++ b/mods/StarletDevil@AzzysJokers/meta.json
@@ -9,6 +9,6 @@
   "author": "Starlet Devil",
   "repo": "https://github.com/AstrumNativus/AzzysJokers",
   "downloadURL": "https://github.com/AstrumNativus/AzzysJokers/archive/refs/tags/v1.2.2.zip",
-  "automatic-version-check": false,
+  "automatic-version-check": true,
   "version": "v1.2.2"
 }


### PR DESCRIPTION
this mod used a release tag (with no extra assets) and originally had `automatic-verison-check: true`, although auto updates for tags weren't implemented, so this field was set to `false` by index maintainers. now that this is supported im making this patch to restore `automatic-version-check`