### PR TITLE
Add Fantom's Preview

### DIFF
--- a/mods/Fantom@Fantom'sPreview/description.md
+++ b/mods/Fantom@Fantom'sPreview/description.md
@@ -1,0 +1,1 @@
+Adds a Score Preview Button

--- a/mods/Fantom@Fantom'sPreview/meta.json
+++ b/mods/Fantom@Fantom'sPreview/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Fantom's Preview",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": ["Quality of Life"],
+  "author": "Fantom, Divvy",
+  "repo": "https://github.com/Fantom-Balatro/Fantoms-Preview",
+  "downloadURL": "https://github.com/Fantom-Balatro/Fantoms-Preview/releases/latest/download/Fantoms-Preview.zip",
+  "folderName": "Fantoms-Preview",
+  "version": "2.2.0",
+  "automatic-version-check": true
+}


### PR DESCRIPTION
Fantom's Preview is a version of Divvy's Preview specifically made for use with the Multiplayer Mod. Gives a button which can be pressed for a score preview.