### PR TITLE
[Sticky Fingers] Remove `folderName` field

### DIFF
--- a/mods/Eramdam@StickyFingers/meta.json
+++ b/mods/Eramdam@StickyFingers/meta.json
@@ -2,13 +2,10 @@
   "title": "Sticky Fingers",
   "requires-steamodded": true,
   "requires-talisman": false,
-  "categories": [
-    "Quality of Life"
-  ],
+  "categories": ["Quality of Life"],
   "author": "Eramdam",
   "repo": "https://github.com/eramdam/sticky-fingers/",
   "downloadURL": "https://github.com/eramdam/sticky-fingers/archive/refs/heads/main.zip",
   "automatic-version-check": true,
-  "folderName": "sticky-fingers",
   "version": "8cdac02"
 }


### PR DESCRIPTION
I've fixed the structure of the mod such that all the lovely files are at the root, meaning I _should_ be able to remove `folderName` which was causing issues (I assumed it meant BMM would look for `$MODS/sticky-fingers/sticky-fingers` and not `$MODS/sticky-fingers` 😅