### PR TITLE
Update Bunco link to jumbocarrot's fork

### DIFF
--- a/mods/Firch@Bunco/meta.json
+++ b/mods/Firch@Bunco/meta.json
@@ -8,8 +8,8 @@
     "Quality of Life"
   ],
   "author": "Firch",
-  "repo": "https://github.com/Firch/Bunco",
-  "downloadURL": "https://github.com/Firch/Bunco/releases/download/5.1/Bunco-5.1.zip",
+  "repo": "https://github.com/jumbocarrot0/Bunco",
+  "downloadURL": "https://github.com/jumbocarrot0/Bunco/archive/refs/heads/main.zip",
   "folderName": "Bunco",
   "version": "5.1",
   "automatic-version-check": false

--- a/mods/Firch@Bunco/meta.json
+++ b/mods/Firch@Bunco/meta.json
@@ -9,7 +9,7 @@
   ],
   "author": "Firch",
   "repo": "https://github.com/jumbocarrot0/Bunco",
-  "downloadURL": "https://github.com/jumbocarrot0/Bunco/archive/refs/heads/main.zip",
+  "downloadURL": "https://github.com/jumbocarrot0/Bunco/releases/download/5.2-JumboFork/Bunco.5.2.JumboFork.zip",
   "folderName": "Bunco",
   "version": "5.1",
   "automatic-version-check": false


### PR DESCRIPTION
The current link crashes on startup with latest Steamodded; this version fixes that error.