### PR TITLE
Make Trif3ctal@LuckyRabbit downloadURL use main rather than latest release

### DIFF
--- a/mods/Trif3ctal@LuckyRabbit/meta.json
+++ b/mods/Trif3ctal@LuckyRabbit/meta.json
@@ -7,7 +7,7 @@
   ],
   "author": "Fennex",
   "repo": "https://github.com/Trif3ctal/Lucky-Rabbit",
-  "downloadURL": "https://github.com/Trif3ctal/Lucky-Rabbit/archive/refs/tags/v1.1.4a.zip",
+  "downloadURL": "https://github.com/Trif3ctal/Lucky-Rabbit/archive/refs/heads/main.zip",
   "folderName": "LuckyRabbit",
   "automatic-version-check": true,
   "version": "v1.1.4a"

--- a/mods/Trif3ctal@LuckyRabbit/meta.json
+++ b/mods/Trif3ctal@LuckyRabbit/meta.json
@@ -10,5 +10,5 @@
   "downloadURL": "https://github.com/Trif3ctal/Lucky-Rabbit/archive/refs/heads/main.zip",
   "folderName": "LuckyRabbit",
   "automatic-version-check": true,
-  "version": "v1.1.4a"
+  "version": "2e906d4"
 }


### PR DESCRIPTION
I've been putting out releases more often given that I assumed this was the only way to update the mod on the mod manager - evidently, I was wrong. I would prefer if the mod updated for every change to main, that way updates can be much more seamless.