### PR TITLE
feat(schema): add `last-updated` field

### DIFF
--- a/.github/scripts/requirements.lock
+++ b/.github/scripts/requirements.lock
@@ -1,5 +1,5 @@
-certifi==2025.1.31
-charset-normalizer==3.4.1
+certifi==2025.4.26
+charset-normalizer==3.4.2
 idna==3.10
 requests==2.32.3
 urllib3==2.4.0

--- a/.github/scripts/update_mod_versions.py
+++ b/.github/scripts/update_mod_versions.py
@@ -15,6 +15,8 @@ import requests
 GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
 HEADERS = {'Authorization': f'token {GITHUB_TOKEN}'} if GITHUB_TOKEN else {}
 
+TIME_NOW = int(time.time())
+
 def extract_repo_info(repo_url):
     """Extract owner and repo name from GitHub repo URL."""
     match = re.search(r'github\.com/([^/]+)/([^/]+)', repo_url)
@@ -190,6 +192,7 @@ def process_mod(start_timestamp, name, meta_file):
         f"✅ Updating {name} from {current_version} to {new_version} ({source})"
     )
     meta['version'] = new_version
+    meta['last-updated'] = TIME_NOW
     if "/archive/refs/tags/" in download_url:
         meta['downloadURL'] = f"{repo_url}/archive/refs/tags/{meta['version']}.zip"
     

--- a/mods/kasimeka@typist/meta.json
+++ b/mods/kasimeka@typist/meta.json
@@ -10,5 +10,6 @@
   "repo": "https://github.com/kasimeka/balatro-typist-mod",
   "downloadURL": "https://github.com/kasimeka/balatro-typist-mod/archive/refs/tags/1.7.2.zip",
   "automatic-version-check": true,
-  "version": "1.7.2"
+  "version": "1.7.2",
+  "last-updated": 1746669345
 }

--- a/schema/meta.schema.json
+++ b/schema/meta.schema.json
@@ -36,13 +36,17 @@
       "type": "string",
       "pattern": "^[^<>:\"/\\|?*]+$"
     },
-	"version": {
+    "version": {
       "type": "string"
     },
-	"automatic-version-check": {
+    "automatic-version-check": {
       "type": "boolean"
+    },
+    "last-updated": {
+      "type": "integer",
+      "minimum": 0,
+      "exclusiveMaximum": 18446744073709551616
     }
   },
   "required": ["title", "requires-steamodded", "requires-talisman", "categories", "author", "repo", "downloadURL"]
 }
-


### PR DESCRIPTION
the time format is unix epoch (seconds) timestamps, which is just a 64bit integer. this can be parsed very easily into stdlib time objects both in python & rust, and can also be parsed and manipulated with the `date` command