### PR TITLE
Add riosodu@rebalanced-stakes mod

### DIFF
--- a/mods/riosodu@rebalanced-stakes/description.md
+++ b/mods/riosodu@rebalanced-stakes/description.md
@@ -1,0 +1,35 @@
+# Rebalanced Stakes
+
+This mod aims to provide a more engaging and balanced difficulty curve for Balatro's higher Stakes, particularly addressing the often-criticized `-1 Discard` penalty of the vanilla Blue Stake. As acknowledged by LocalThunk, that modifier could feel overly punishing and have limited the viability of bigger size poker hands; this mod offers an alternative approach while that change is pending in the vanilla game.
+
+## How It Works
+Instead of introducing entirely new harsh mechanics early on, this mod shifts existing shop Joker limitations (Perishable, Rental) to earlier Stakes (Blue and Orange, respectively). The Gold Stake is then redesigned to offer a distinct economic and endurance challenge.
+
+## Key Features
+- **Blue Stake (Stake 5):**
+    - Removes the `-1 Discard` penalty
+    - Introduces Perishable Jokers to the shop pool *(effect moved from vanilla Orange Stake)*
+
+- **Orange Stake (Stake 7):**
+    - Removes the Perishable Joker effect
+    - Introduces Rental Jokers to the shop pool *(effect moved from vanilla Gold Stake)*
+
+- **Gold Stake (Stake 8):**
+    - Removes the Rental Joker effect
+    - Introduces two significant new challenges:
+        - **Increased Interest Threshold:** You now need **_$6_** (up from **_$5_**) to earn each dollar of interest.
+        The interest cap scales accordingly (_$30_ -> _$60_ -> _$120_) so you can still gain up to _$5_, _$10_ _(Seed Money)_ and _$20_ _(Money Tree)_
+        - **Increased Run Length:** The Final Ante required to win is increased to **Ante 9** _(up from Ante 8)_
+
+## Installation
+1. **Requirements**: Download and install [Steamodded](https://github.com/Steamodded/smods)
+2. **Download**: Get the latest version of Rebalanced Stakes from the releases
+3. **Install Location**: Extract to `%appdata%\Balatro\Mods` on Windows
+
+## Design Notes
+The goal is a smoother ramp-up of difficulty, without limiting the hand types you can play while also having a challenging final stake that tests your economic management and run longevity rather than just adding more restrictions.
+
+*Note: On gold stake, instead of the interest rework, at first I tried removing the rewards of big blind. Turns out it was an even more awful experience than -1 discard. The greatly reduced money income coupled with rental jokers was just brutal.*
+
+## Support
+Suggestions and feedback are welcome! Let me know what you think of the rebalanced progression.

--- a/mods/riosodu@rebalanced-stakes/meta.json
+++ b/mods/riosodu@rebalanced-stakes/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Rebalanced Stakes",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": [
+    "Content",
+    "Miscellaneous"
+  ],
+  "author": "Riosodu",
+  "repo": "https://github.com/gfreitash/balatro-mods",
+  "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download/rebalanced-stakes__latest/rebalanced-stakes.zip",
+  "folderName": "rebalanced-stakes",
+  "automatic-version-check": true,
+  "version": "1.2.1"
+}


### PR DESCRIPTION
New mod submission: 'Rebalanced Stakes' (directory: rebalanced-stakes)

**Mod Details:**
- Author: riosodu
- Name: Rebalanced Stakes (Directory: rebalanced-stakes)

**Mod:** `riosodu@rebalanced-stakes`
**Description:** Removes the -1 discard from blue stake, moving joker stickers to earlier stakes while completely reworking the gold stake to still be a challenge without restricting played hands

**Source Files (in gfreitash/balatro-mods):** https://github.com/gfreitash/balatro-mods/tree/main/rebalanced-stakes
**Triggering Commit (in gfreitash/balatro-mods):** [30b38ae](https://github.com/gfreitash/balatro-mods/commit/30b38ae6611296ea255549e050b1fb34730b243f)

---
**Note:** This PR was created automatically. Review comments and feedback are welcome.