### PR TITLE
Add Cryptposting to the Balatro Mod Index

### DIFF
--- a/mods/Glitchkat10@Cryptposting/description.md
+++ b/mods/Glitchkat10@Cryptposting/description.md
@@ -1,0 +1,8 @@
+# Cryptposting
+A collection of the Cryptid community's unfunniest shitposts.<br>
+Requires Cryptid, obviously.<br>
+Order of items in the collection is based off of the order that they were created in the [Cryptposting Idea Document](https://docs.google.com/document/d/1toiOWh2qfouhZYUSiBEgHxU91lbzgvMfR46bShg67Qs/edit?pli=1&tab=t.0).<br>
+[Cartomancer](https://github.com/stupxd/Cartomancer) is highly recommended to be used with this mod.
+<br>
+<br>
+Join the [Cryptposting Discord](https://discord.gg/Jk9Q9usrNy)!

--- a/mods/Glitchkat10@Cryptposting/meta.json
+++ b/mods/Glitchkat10@Cryptposting/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Cryptposting",
+  "requires-steamodded": true,
+  "requires-talisman": true,
+  "categories": ["Content", "Joker"],
+  "author": "Glitchkat10 and Poker The Poker",
+  "repo": "https://github.com/kierkat10/Cryptposting",
+  "downloadURL": "https://github.com/kierkat10/Cryptposting/archive/refs/heads/main.zip",
+  "folderName": "Cryptposting",
+  "version": "0.0.0",
+  "automatic-version-check": true
+}


### PR DESCRIPTION
Add Cryptposting, a relatively new mod that is garnering popularity, to the Balatro Mod Index.