### PR TITLE
fix?(schema): make `version` a required field.

### DIFF
--- a/mods/Mathguy@CruelBlinds/meta.json
+++ b/mods/Mathguy@CruelBlinds/meta.json
@@ -5,5 +5,7 @@
   "categories": ["Content"],
   "author": "Mathguy",
   "repo": "https://github.com/Mathguy23/Cruel-Blinds",
+  "automatic-version-check": true,
+  "version": "0b0bcf1",
   "downloadURL": "https://github.com/Mathguy23/Cruel-Blinds/archive/refs/heads/main.zip"
 }

--- a/mods/Mathguy@Grim/meta.json
+++ b/mods/Mathguy@Grim/meta.json
@@ -5,5 +5,7 @@
   "categories": ["Content"],
   "author": "Mathguy",
   "repo": "https://github.com/Mathguy23/Grim",
+  "automatic-version-check": true,
+  "version": "18d57f5",
   "downloadURL": "https://github.com/Mathguy23/Grim/archive/refs/heads/main.zip"
 }

--- a/schema/meta.schema.json
+++ b/schema/meta.schema.json
@@ -16,7 +16,15 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["Content", "Joker", "Quality of Life", "Technical", "Miscellaneous", "Resource Packs", "API"]
+        "enum": [
+          "Content",
+          "Joker",
+          "Quality of Life",
+          "Technical",
+          "Miscellaneous",
+          "Resource Packs",
+          "API"
+        ]
       },
       "minItems": 1,
       "uniqueItems": true
@@ -36,13 +44,21 @@
       "type": "string",
       "pattern": "^[^<>:\"/\\|?*]+$"
     },
-	"version": {
+    "version": {
       "type": "string"
     },
-	"automatic-version-check": {
+    "automatic-version-check": {
       "type": "boolean"
     }
   },
-  "required": ["title", "requires-steamodded", "requires-talisman", "categories", "author", "repo", "downloadURL"]
+  "required": [
+    "title",
+    "requires-steamodded",
+    "requires-talisman",
+    "categories",
+    "author",
+    "repo",
+    "downloadURL",
+    "version"
+  ]
 }
-


### PR DESCRIPTION
i don't think the version field should be optional, since part of a mod manager's functionality is keeping track of versions to detect updates, if a user's mod won't ever be versioned or receive updates they can just set the version field to _anything_ and disable auto version checks instead of omitting the field.