### PR TITLE
Update riosodu@black-seal mod

### DIFF
--- a/mods/riosodu@black-seal/meta.json
+++ b/mods/riosodu@black-seal/meta.json
@@ -7,8 +7,8 @@
   ],
   "author": "Riosodu",
   "repo": "https://github.com/gfreitash/balatro-mods",
-  "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download/black-seal__latest/black-seal.zip",
+  "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download//black-seal.zip",
   "folderName": "black-seal",
   "automatic-version-check": true,
-  "version": "qol-bundle__latest-v1.1.2"
+  "version": "3.2.8"
 }


### PR DESCRIPTION
Automated update of the mod 'Black Seal' (directory: black-seal)

**Mod:** `riosodu@black-seal`
**Description:** Adds a Black Seal to the game with a configurable spawn chance.

**Source Files (in gfreitash/balatro-mods):** https://github.com/gfreitash/balatro-mods/tree/main/black-seal
**Triggering Commit (in gfreitash/balatro-mods):** [608b66a](https://github.com/gfreitash/balatro-mods/commit/608b66a4ec7be919ea139eec063f73f66ace3033)

---
**Note:** This PR was created automatically. Review comments and feedback are welcome.