### PR TITLE
Update riosodu@rebalanced-stakes mod

### DIFF
--- a/mods/riosodu@rebalanced-stakes/meta.json
+++ b/mods/riosodu@rebalanced-stakes/meta.json
@@ -8,8 +8,8 @@
   ],
   "author": "Riosodu",
   "repo": "https://github.com/gfreitash/balatro-mods",
-  "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download/rebalanced-stakes__latest/rebalanced-stakes.zip",
+  "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download//rebalanced-stakes.zip",
   "folderName": "rebalanced-stakes",
   "automatic-version-check": true,
-  "version": "qol-bundle__latest-v1.1.2"
+  "version": "1.2.9"
 }


### PR DESCRIPTION
Automated update of the mod 'Rebalanced Stakes' (directory: rebalanced-stakes)

**Mod:** `riosodu@rebalanced-stakes`
**Description:** Removes the -1 discard from blue stake, moving joker stickers to earlier stakes while completely reworking the gold stake to still be a challenge without restricting played hands

**Source Files (in gfreitash/balatro-mods):** https://github.com/gfreitash/balatro-mods/tree/main/rebalanced-stakes
**Triggering Commit (in gfreitash/balatro-mods):** [608b66a](https://github.com/gfreitash/balatro-mods/commit/608b66a4ec7be919ea139eec063f73f66ace3033)

---
**Note:** This PR was created automatically. Review comments and feedback are welcome.