### PR TITLE
Update riosodu@black-seal mod to v3.2.8

### DIFF
--- a/mods/riosodu@black-seal/meta.json
+++ b/mods/riosodu@black-seal/meta.json
@@ -9,6 +9,5 @@
   "repo": "https://github.com/gfreitash/balatro-mods",
   "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download/black-seal__latest/black-seal.zip",
   "folderName": "black-seal",
-  "automatic-version-check": true,
-  "version": "qol-bundle__latest"
+  "automatic-version-check": true
 }


### PR DESCRIPTION
Automated update of the mod 'Black Seal' (directory: black-seal) to version `v3.2.8`.

**Mod:** `riosodu@black-seal`
**Description:** Adds a Black Seal to the game with a configurable spawn chance.

**Source Files (in gfreitash/balatro-mods):** https://github.com/gfreitash/balatro-mods/tree/main/black-seal
**Triggering Commit (in gfreitash/balatro-mods):** [3d5d128](https://github.com/gfreitash/balatro-mods/commit/3d5d128c91fb434bfaf8c30f04ee75723f5c78bd)

---
**Note:** This PR was created automatically. Review comments and feedback are welcome.