### PR TITLE
Update riosodu@black-seal mod to v3.2.10

### DIFF
--- a/mods/riosodu@black-seal/meta.json
+++ b/mods/riosodu@black-seal/meta.json
@@ -7,9 +7,9 @@
   ],
   "author": "Riosodu",
   "repo": "https://github.com/gfreitash/balatro-mods",
-  "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download/black-seal__latest/black-seal.zip",
+  "downloadURL": "https://github.com/gfreitash/balatro-mods/releases/download/black-seal__v3.2.10/black-seal.zip",
   "folderName": "black-seal",
   "automatic-version-check": true,
   "fixed-release-tag-updates": true,
-  "version": "20250624_015936"
+  "version": "3.2.10"
 }


### PR DESCRIPTION
Automated update of the mod 'Black Seal' (directory: black-seal) to version `v3.2.10`.

**Mod:** `riosodu@black-seal`
**Description:** Adds a Black Seal to the game with a configurable spawn chance.
Changes:
- changed metadata

**Source Files (in gfreitash/balatro-mods):** https://github.com/gfreitash/balatro-mods/tree/main/black-seal
**Triggering Commit (in gfreitash/balatro-mods):** [be30a0b](https://github.com/gfreitash/balatro-mods/commit/be30a0bae676e19ad062ca18ce8a1ba3b36f47fe)

---
**Note:** This PR was created automatically. Review comments and feedback are welcome.