### PR TITLE
chore: delete meaningless check-mod step

### DIFF
--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -149,12 +149,3 @@ jobs:
               fi
             fi
           done < changed_mods.txt
-
-  review-and-approve:
-    needs: validate # This job will only run after 'validate' completes successfully.
-    runs-on: ubuntu-latest
-    environment:
-      name: mod-review # This is the environment you created earlier.
-    steps:
-      - name: Await Approval from Maintainers
-        run: echo "Waiting for manual approval by maintainers..."


### PR DESCRIPTION
ive been always puzzled by what kind of environment is the schema check deploying or why is the deployments api being invoked instead of `check-mods` being a pure check but never actually bothered to read the action