### PR TITLE
Add GoonsTowerDefense@Goonlatro

### DIFF
--- a/mods/GoonsTowerDefense@Goonlatro/description.md
+++ b/mods/GoonsTowerDefense@Goonlatro/description.md
@@ -1,0 +1,33 @@
+# Goonlatro - The GTD Balatro Mod
+
+A mod and texture pack for Balatro that adds various Jokers and Consumables to the game based on GTD Discord references.
+
+Don't expect this to be good cause it's not.
+
+We hope you have fun playing it, we know we did.
+
+Requires [Malverk](https://github.com/Eremel/Malverk), [Steamodded](https://github.com/Steamodded/smods), and [Lovely](https://github.com/ethangreen-dev/lovely-injector)
+
+## Installation
+Get the latest release from [here](https://github.com/GMO298/goonlatro/releases), unzip the file and place it in your Balatro/Mods folder.
+
+Make sure you have all of the requirements installed.
+
+Finally, start Balatro and have fun!
+
+## Additions
+
+### Jokers
+**Crazy Eights** Joker: (based on the LTLVC5/Grunk bit) X8 Mult, gains X8 Mult on round end.
+
+**Playstyle** Joker: (Inside Joke) Flips all face-down cards to be face-up.
+
+**Click the Bart** Joker: WIP
+
+### Consumables
+**A Big Bag** Spectral Card: With one **cookie** in it.
+
+**Cookie** Spectral Card: Gives back all discards used.
+
+### Decks
+**Take my Playstyle** Deck: Starts with all GTD Cards

--- a/mods/GoonsTowerDefense@Goonlatro/meta.json
+++ b/mods/GoonsTowerDefense@Goonlatro/meta.json
@@ -4,7 +4,7 @@
   "requires-talisman": false,
   "categories": ["Content", "Joker", "Resource Packs"],
   "author": "Goons Tower Defense",
-  "repo": "https://github.com/GoonsTowerDefense/Goonlatrp",
+  "repo": "https://github.com/GoonsTowerDefense/Goonlatro",
   "downloadURL": "https://github.com/GoonsTowerDefense/Goonlatro/archive/refs/heads/main.zip",
   "folderName": "Goonlatro",
   "version": "0.0.2a",

--- a/mods/GoonsTowerDefense@Goonlatro/meta.json
+++ b/mods/GoonsTowerDefense@Goonlatro/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Goonlatro",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": ["Content", "Joker", "Resource Packs"],
+  "author": "Goons Tower Defense",
+  "repo": "https://github.com/GoonsTowerDefense/Goonlatrp",
+  "downloadURL": "https://github.com/GoonsTowerDefense/Goonlatro/archive/refs/heads/main.zip",
+  "folderName": "Goonlatro",
+  "version": "0.0.2a",
+  "automatic-version-check": true
+}


### PR DESCRIPTION
A mod and texture pack for Balatro that adds various Jokers and Consumables to the game based on GTD Discord references.