### PR TITLE
Update riosodu@black-seal mod to v20250902_120043

### DIFF
--- a/mods/riosodu@black-seal/meta.json
+++ b/mods/riosodu@black-seal/meta.json
@@ -11,6 +11,5 @@
   "folderName": "black-seal",
   "automatic-version-check": true,
   "fixed-release-tag-updates": true,
-  "version": "20250902_003050",
-  "last-updated": 1756775970
+  "version": "20250902_120043"
 }


### PR DESCRIPTION
Automated update of the mod 'Black Seal' (directory: black-seal) to version `v20250902_120043`.

**Mod:** `riosodu@black-seal`
**Description:** Adds a Black Seal to the game with a configurable spawn chance.
Changes:
- changed metadata

**Source Files (in gfreitash/balatro-mods):** https://github.com/gfreitash/balatro-mods/tree/main/black-seal
**Triggering Commit (in gfreitash/balatro-mods):** [a1e5fcb](https://github.com/gfreitash/balatro-mods/commit/a1e5fcb61ec070117540d4556eaa6a90a75f08e7)

---
**Note:** This PR was created automatically. Review comments and feedback are welcome.