### PR TITLE
Add Maelmc@Pokermon-Maelmc mod

### DIFF
--- a/mods/Maelmc@Pokermon-Maelmc/description.md
+++ b/mods/Maelmc@Pokermon-Maelmc/description.md
@@ -1,0 +1,1 @@
+A Pokermon extension, that adds Pokémon-related jokers, consumables and other things that aren't (yet) featured in InertSteak's Pokermon mod.

--- a/mods/Maelmc@Pokermon-Maelmc/meta.json
+++ b/mods/Maelmc@Pokermon-Maelmc/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Pokermon-Maelmc",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": [
+    "Content",
+    "Joker"
+  ],
+  "author": "Maelmc",
+  "repo": "https://github.com/Maelmc/Pokermon-Maelmc",
+  "downloadURL": "https://github.com/Maelmc/Pokermon-Maelmc/archive/refs/heads/main.zip",
+  "folderName": "Pokermon-Maelmc",
+  "version": "1.0.0",
+  "automatic-version-check": true
+}


### PR DESCRIPTION
A Pokermon extension, that adds Pokémon-related jokers, consumables and other things that aren't (yet) featured in InertSteak's Pokermon mod.