### PR TITLE
Add Sonfive@PokermonPlus

### DIFF
--- a/mods/Sonfive@PokermonPlus/description.md
+++ b/mods/Sonfive@PokermonPlus/description.md
@@ -1,0 +1,1 @@
+An add-on for Pokermon, which adds Pokemon that aren't in Pokermon yet, as well as new Decks that explore some of the unique parts of the Pokermon mod

--- a/mods/Sonfive@PokermonPlus/meta.json
+++ b/mods/Sonfive@PokermonPlus/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "PokermonPlus",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": [
+    "Content",
+    "Joker"
+  ],
+  "author": "Sonfive",
+  "repo": "https://github.com/SonfiveTV/PokermonPlus",
+  "downloadURL": "https://github.com/SonfiveTV/PokermonPlus/archive/refs/heads/main.zip",
+  "folderName": "PokermonPlus",
+  "version": "1.0.0",
+  "automatic-version-check": true
+}


### PR DESCRIPTION
An add-on for Pokermon, which adds Pokemon that aren't in Pokermon yet, as well as new Decks that explore some of the unique parts of the Pokermon mod