### PR TITLE
ci: remove `/archive/refs/tags/` from non-updating URLs regex

### DIFF
--- a/.github/workflows/check-mod.yml
+++ b/.github/workflows/check-mod.yml
@@ -331,7 +331,7 @@ jobs:
               fi
 
               if [ "$AUTO_CHECK" = "true" ]; then
-                if echo "$DOWNLOAD_URL" | grep -Eq '/blob/|/tree/|/archive/refs/tags/|/releases/latest$|/releases/tag/|github\.com/[^/]+/[^/]+/?$'; then
+                if echo "$DOWNLOAD_URL" | grep -Eq '/blob/|/tree/|/releases/latest$|/releases/tag/|github\.com/[^/]+/[^/]+/?$'; then
                   echo "- '$MOD_DIR': automatic-version-check requires an auto-updating file URL" >> "$REPORT_FILE"
                 fi
 


### PR DESCRIPTION
fixes #641
in the `/archive/refs/tags/` case the url does point at a specific release by its name, but the auto-updater script parses release URLs and updates them to the latest tag, so it supports automatic updates. this is code ive contributed many months ago and have always worked fine