### PR TITLE
Add Hebrew Translation mod

### DIFF
--- a/mods/HenHat583@HebrewBalatro/description.md
+++ b/mods/HenHat583@HebrewBalatro/description.md
@@ -1,0 +1,19 @@
+# תרגום עברי לבלאטרו / Hebrew Translation for Balatro
+
+תרגום מלא של המשחק Balatro לעברית עם תמיכה מלאה בכתיבה מימין לשמאל (RTL) ופונט פיקסל עברי.
+
+Full Hebrew RTL translation for Balatro with a custom Hebrew pixel font.
+
+## Features
+- Complete Hebrew translation of all in-game text
+- Full RTL (right-to-left) text rendering support
+- Custom Hebrew pixel font matching Balatro's visual style
+- ₪ (shekel) instead of $
+- Compatible with latest Balatro version
+
+## Requirements
+- Steamodded >= 0.9.8
+- Lovely Injector
+
+## Installation
+Copy the mod folder to `%AppData%\Balatro\Mods\`, then select Hebrew in Settings → Language.

--- a/mods/HenHat583@HebrewBalatro/meta.json
+++ b/mods/HenHat583@HebrewBalatro/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Hebrew Translation / תרגום עברי",
+  "author": "HenHat583",
+  "version": "1.0.1",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": ["Technical", "Quality of Life"],
+  "repo": "https://github.com/HenHat583/HebrewBalatro",
+  "downloadURL": "https://github.com/HenHat583/HebrewBalatro/releases/latest/download/HebrewBalatro-1.0.1.zip"
+}


### PR DESCRIPTION
Full Hebrew RTL translation for Balatro by HenHat583.

- Complete Hebrew translation of all in-game text
- RTL (right-to-left) BiDi text rendering
- Custom Hebrew pixel font
- Shekel (₪) symbol instead of $

Requires: Steamodded >= 0.9.8 + Lovely Injector