### PR TITLE
Fix Hebrew Translation version check (fixed-release-tag-updates)

### DIFF
--- a/mods/HenHat583@HebrewBalatro/meta.json
+++ b/mods/HenHat583@HebrewBalatro/meta.json
@@ -9,8 +9,8 @@
     "Quality of Life"
   ],
   "repo": "https://github.com/HenHat583/HebrewBalatro",
-  "downloadURL": "https://github.com/HenHat583/HebrewBalatro/releases/latest/download/HebrewBalatro-1.0.9.zip",
+  "downloadURL": "https://github.com/HenHat583/HebrewBalatro/releases/download/v1.0.12/HebrewBalatro-1.0.12.zip",
   "automatic-version-check": true,
-  "fixed-release-tag-updates": false,
+  "fixed-release-tag-updates": true,
   "last-updated": 1782069349
 }


### PR DESCRIPTION
As requested by maintainers (@pawPatoes, @theminizilla) on #676.

The previous `downloadURL` pointed at `releases/latest/download/HebrewBalatro-1.0.9.zip`. Because the release asset name is versioned, that fixed filename under `/latest/` 404s once a newer release exists — and in `LATEST_TAG` mode the auto-version script never rewrites the `downloadURL`, so it stayed pinned to the missing `1.0.9` asset.

Switched to the fixed-release-tag pattern so `update_mod_versions.py` keeps the asset filename fresh and validation stays green:

- `downloadURL` → `releases/download/v1.0.12/HebrewBalatro-1.0.12.zip` (real, fixed-tag asset)
- `fixed-release-tag-updates: true`
- `automatic-version-check: true` (kept)
- `version` → `v1.0.12`

Verified the asset exists at the new URL.