### PR TITLE
Hebrew Translation: v1.0.13 + folderName (fixes BMM install)

### DIFF
--- a/mods/HenHat583@HebrewBalatro/meta.json
+++ b/mods/HenHat583@HebrewBalatro/meta.json
@@ -1,7 +1,7 @@
 {
   "title": "Hebrew Translation / תרגום עברי",
   "author": "HenHat583",
-  "version": "v1.0.12",
+  "version": "v1.0.13",
   "requires-steamodded": true,
   "requires-talisman": false,
   "categories": [
@@ -9,7 +9,7 @@
     "Quality of Life"
   ],
   "repo": "https://github.com/HenHat583/HebrewBalatro",
-  "downloadURL": "https://github.com/HenHat583/HebrewBalatro/releases/download/v1.0.12/HebrewBalatro-1.0.12.zip",
+  "downloadURL": "https://github.com/HenHat583/HebrewBalatro/releases/download/v1.0.13/HebrewBalatro-1.0.13.zip",
   "folderName": "HebrewBalatro",
   "automatic-version-check": true,
   "fixed-release-tag-updates": true,

--- a/mods/HenHat583@HebrewBalatro/meta.json
+++ b/mods/HenHat583@HebrewBalatro/meta.json
@@ -10,6 +10,7 @@
   ],
   "repo": "https://github.com/HenHat583/HebrewBalatro",
   "downloadURL": "https://github.com/HenHat583/HebrewBalatro/releases/download/v1.0.12/HebrewBalatro-1.0.12.zip",
+  "folderName": "HebrewBalatro",
   "automatic-version-check": true,
   "fixed-release-tag-updates": true,
   "last-updated": 1782069349


### PR DESCRIPTION
The mod `title` is `Hebrew Translation / תרגום עברי`, which contains a `/` (an invalid filename character). With no `folderName` set, the mod manager derives the install folder from the title and fails on the `/`, producing a broken install (a single stray file in `Mods/` instead of a `HebrewBalatro/` folder). End users report the mod "does nothing" after install.

Adding `"folderName": "HebrewBalatro"` (matching the top-level folder inside the release zip) so the mod installs into a clean, valid `Mods/HebrewBalatro/` directory.

No other fields changed.