### PR TITLE
Remove content counters and mod version from description

### DIFF
--- a/mods/PorkyLIVE@Porkify/description.md
+++ b/mods/PorkyLIVE@Porkify/description.md
@@ -2,23 +2,14 @@
 
 Porkify is a large content mod for Balatro focused on adding more run-defining decisions without slowing the game down. It expands the game with a broad mix of custom Jokers, Consumables, decks, blinds, enhancements, editions, seals, stickers, vouchers, challenges, and custom stakes, alongside light balance changes and extra mechanics to make runs feel less predictable.
 
-This mod requires [Steamodded](https://github.com/Steamodded/smods) above version `1.0.0~BETA-1620a` to work
+This mod requires [Steamodded](https://github.com/Steamodded/smods) `>= 1.0.0~BETA-1620a` to function properly.
 
 ## Included Content
 
-- 82 Jokers
-- 54 Consumables
-- 10 Decks
-- 2 Vouchers
-- 10 Enhancements
-- 5 Editions
-- 8 Seals
-- 9 Booster Packs
-- 15 Blinds
-- 1 Sticker set
-- 8 Stakes
-- 20 Challenges
+Porkify adds a wide spread of new content across most of Balatro's systems, including:
 
-## Version
-
-Current mod version: `1.3.0`
+- Custom Jokers and Consumables
+- New Decks, Blinds, and Booster Packs
+- Custom Enhancements, Editions, Seals, Stickers, and Vouchers
+- Additional Stakes and Challenges
+- Extra mechanics and balance tweaks layered into the base game


### PR DESCRIPTION
The description of the mod has been updated to remove the mod version, as well as the counters for what is included in the mod, as continuously keeping these up-to-date would require a pull request every time the mod updates to a new version.