### PR TITLE
Add Balatro Stats

### DIFF
--- a/mods/jagodben@BalatroStats/description.md
+++ b/mods/jagodben@BalatroStats/description.md
@@ -1,0 +1,13 @@
+# Balatro Stats
+
+Tracks your all-time personal best for every scaling Joker and shows it right on the card — `Best: $66` on Egg, `Best: +48 Mult` on Ride the Bus, peak `X3.4` on Obelisk. Planet cards record the highest level each poker hand has ever reached, shown in the Card Stats screen and the mod's Records tab. Per profile, persists across runs, never touches your saves.
+
+Also expands the built-in **Card Stats** screen to page through every discovered card — vanilla and modded — instead of just the top 10.
+
+## Features
+
+- 33 vanilla Jokers tracked: event-scalers (Egg, Ride the Bus, Obelisk, Canio...) and derived Jokers (Bull, Swashbuckler, Throwback, Cloud 9...)
+- Poker-hand level records for every Planet, counting all upgrade sources
+- Records tab with per-profile reset
+- Modded Jokers tracked automatically when they scale via `SMODS.scale_card`, or precisely via an inert `bstat` declaration — no dependency on this mod needed
+- Config toggles for tooltips, modded tracking, and the Card Stats expansion

--- a/mods/jagodben@BalatroStats/meta.json
+++ b/mods/jagodben@BalatroStats/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Balatro Stats",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": [
+    "Quality of Life"
+  ],
+  "author": "jagodben",
+  "repo": "https://github.com/jagodben/Balatro-Record-Stats-Mod",
+  "downloadURL": "https://github.com/jagodben/Balatro-Record-Stats-Mod/releases/latest/download/BalatroStats.zip",
+  "folderName": "BalatroStats",
+  "automatic-version-check": true,
+  "version": "0.3.0",
+  "last-updated": 1785116100
+}


### PR DESCRIPTION
Adds Balatro Stats - records all-time personal bests for scaling Jokers (shown on the card tooltip), derived Jokers like Bull and Swashbuckler, and poker-hand levels shown on Planet cards in the Card Stats screen. Also expands Card Stats to page through every discovered card instead of the top 10.

- Repo: https://github.com/jagodben/Balatro-Record-Stats-Mod
- Download: https://github.com/jagodben/Balatro-Record-Stats-Mod/releases/latest/download/BalatroStats.zip (v0.3.0 release asset)
- Requires Steamodded (>= 1.0.0~BETA-1229a), no Talisman