### PR TITLE
Update Card Parser automatic download link

### DIFF
--- a/mods/Hawker-Possessed@Card-Parser/meta.json
+++ b/mods/Hawker-Possessed@Card-Parser/meta.json
@@ -7,9 +7,9 @@
   ],
   "author": "Hawker, Possessed",
   "repo": "https://github.com/Hawker-Balatro-Mods/Card-Parser",
-  "downloadURL": "https://github.com/Hawker-Balatro-Mods/Card-Parser/releases/download/V1.0.0/Card.Parser.zip",
-  "version": "20260709_191925",
+  "downloadURL": "https://github.com/Hawker-Balatro-Mods/Card-Parser/releases/latest/download/Card.Parser.zip",
+  "version": "V1.1.0",
   "automatic-version-check": true,
-  "fixed-release-tag-updates": true,
+  "fixed-release-tag-updates": false,
   "last-updated": 1783629719
 }


### PR DESCRIPTION
Change Card Parser's automatic update link to point to the latest build zip. This pr will close #809 done correctly