### PR TITLE
Add Liminal-Drenge@Spectral-Arcana mod

### DIFF
--- a/mods/Liminal-Drenge@Spectral-Arcana/description.md
+++ b/mods/Liminal-Drenge@Spectral-Arcana/description.md
@@ -1,0 +1,1 @@
+A small Balatro mod that replaces Tarot cards with Spectral cards.

--- a/mods/Liminal-Drenge@Spectral-Arcana/meta.json
+++ b/mods/Liminal-Drenge@Spectral-Arcana/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "Spectral Arcana",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": [
+    "Miscellaneous"
+  ],
+  "author": "Liminal Drenge",
+  "repo": "https://github.com/LiminalDrenge/Spectral-Arcana",
+  "downloadURL": "https://github.com/LiminalDrenge/Spectral-Arcana/releases/download/Misc/SpectralArcana.zip",
+  "version": "1.0.0",
+  "automatic-version-check": true,
+  "fixed-release-tag-updates": true
+}


### PR DESCRIPTION
## Mod Submission

- Path: `mods/Liminal-Drenge@Spectral-Arcana/`
- Generated with Balatro Mod Index Helper