### PR TITLE
Update riosodu@qol-bundle mod to v20260903_230842

### DIFF
--- a/mods/riosodu@qol-bundle/description.md
+++ b/mods/riosodu@qol-bundle/description.md
@@ -15,7 +15,7 @@ Balance and gameplay changes that feels good, configurable per feature. Bad mod 
 - **Satellite Joker Rework**: Satellite now gives gold equal to half the highest poker hand level (rounded up).
 - **Controlled Sigil**: Sigil now requires selecting a card first and converts all cards to selected card's suit instead of random suit.
 - **Controlled Ouija**: Ouija now requires selecting a card first and converts all cards to selected card's rank instead of random rank.
-- **Loyalty Card Rounds Mode**: Loyalty Card triggers based on rounds instead of hands played for more predictable timing and easier to plan around.
+- **Loyalty Card Rounds Mode**: Loyalty Card triggers based on rounds instead of hands, becoming active for a whole round after every 3 rounds. Skipping a blind counts twice, but raises the chance of the card being permanently disabled (a clean redeem lowers it again).
 - **Splash Joker Retrigger**: Splash Joker additionally retriggers two random scoring cards.
 - **Ceremonial Dagger Common**: Makes Ceremonial Dagger joker Common rarity with reduced cost ($3 instead of $6).
 - **Mail-In Rebate Uncommon**: Makes Mail-In Rebate joker Uncommon rarity (was Common rarity - makes it rarer).
@@ -24,7 +24,7 @@ Balance and gameplay changes that feels good, configurable per feature. Bad mod 
 - **Interest on Skip**: Gain interest when skipping blinds, calculated and awarded before obtaining the tag.
 - **Paperback Compatibility**: Added compatibility for Paperback mod's Jester of Nihil joker and suit considerations for Smeared Joker.
 - **Nerf Hanging Chad**: Makes Hanging Chad joker Uncommon rarity and more expensive (cost $7 instead of $6).
-- **Castle Checkered Reliability**: Castle now counts either Clubs and Spades or Hearts and Diamonds, making it as reliable as in the checkered deck. If Paperback mod is installed, light suits or dark suits will be used instead.
+- **Castle Checkered Reliability**: Castle now counts either Clubs and Spades or Hearts and Diamonds. The suit group follows your deck composition, so suit fixing makes Castle more reliable and the checkered deck always counts the same group. If Paperback mod is installed, light suits or dark suits will be used instead.
 - **Yorick Enhancement**: Yorick now gains a configurable amount (+1.5x for each 23 cards instead of +1x).
 - **Reworked Magic Trick and Illusion Vouchers**: 
     - Magic Trick is now a "better" Illusion voucher with playing cards in shop appearing with enhancements, editions and seals (actually spawn instead of the bugged vanilla). 

--- a/mods/riosodu@qol-bundle/meta.json
+++ b/mods/riosodu@qol-bundle/meta.json
@@ -11,6 +11,5 @@
   "folderName": "qol-bundle",
   "automatic-version-check": true,
   "fixed-release-tag-updates": true,
-  "version": "20260828_221019",
-  "last-updated": 1787972200
+  "version": "20260903_230842"
 }


### PR DESCRIPTION
Automated update of the mod 'QoL Bundle' (directory: qol-bundle) to version `v20260903_230842`.

**Mod:** `riosodu@qol-bundle`
**Description:** Balance and gameplay changes that feels good, configurable per feature. Bad mod name, too late now.
Changes:
- changed description

**Source Files (in gfreitash/balatro-mods):** https://github.com/gfreitash/balatro-mods/tree/main/qol-bundle
**Triggering Commit (in gfreitash/balatro-mods):** [ea672d5](https://github.com/gfreitash/balatro-mods/commit/ea672d5e935774c50c504f00fb2c62f4114025a0)

---
**Note:** This PR was created automatically. Review comments and feedback are welcome.