### PR TITLE
Add DoubleAA@BalatroObserver mod

### DIFF
--- a/mods/DoubleAA@BalatroObserver/description.md
+++ b/mods/DoubleAA@BalatroObserver/description.md
@@ -1,0 +1,1 @@
+View player-visible Balatro game data through raw JSON snapshot files or a live local HTML dashboard.

--- a/mods/DoubleAA@BalatroObserver/meta.json
+++ b/mods/DoubleAA@BalatroObserver/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "BalatroObserver",
+  "requires-steamodded": true,
+  "requires-talisman": false,
+  "categories": [
+    "Miscellaneous",
+    "API"
+  ],
+  "author": "DoubleAA",
+  "repo": "https://github.com/DoubleAAdev/BalatroObserver",
+  "downloadURL": "https://github.com/DoubleAAdev/BalatroObserver/releases/latest/download/BalatroObserver-v1.1.1.zip",
+  "version": "1.1.1",
+  "automatic-version-check": true,
+  "fixed-release-tag-updates": false
+}


### PR DESCRIPTION
## Mod Submission

- Path: `mods/DoubleAA@BalatroObserver/`
- Generated with Balatro Mod Index Helper